### PR TITLE
Fix further bug in OneFile

### DIFF
--- a/ModelOutputLib/OneFile/OneFile.py
+++ b/ModelOutputLib/OneFile/OneFile.py
@@ -24,17 +24,16 @@ class OneFile(ModelOutput):
     # Check if csv file exists in directory
     # If not, create file
     def createFileWithHeader(self, filename):
-        files_in_folder = os.listdir(self.output_dir)
         file = open(os.path.join(self.output_dir, filename), "w")
 
         string = ""
-        if filename not in files_in_folder:
-            string += 'tree' + self.delimiter + 'time' + self.delimiter + 'x' + \
-                      self.delimiter + 'y'
-            string = self.addSelectedHeadings(string, self.delimiter)
+        string += 'tree' + self.delimiter + 'time' + self.delimiter + 'x' + \
+                  self.delimiter + 'y'
+        string = self.addSelectedHeadings(string, self.delimiter)
 
-            string += "\n"
-            file.write(string)
+        string += "\n"
+        file.write(string)
+
         file.close()
 
     def outputContent(self, tree_groups, time, **kwargs):


### PR DESCRIPTION
OneFile was failing to include a header row in new output files, when an output file was already present in the output directory. This is now fixed -- a header row is always added. 