### PR TITLE
Min. grid size

### DIFF
--- a/ResourceLib/AboveGround/SimpleAsymmetricZOI/SimpleAsymmetricZOI.py
+++ b/ResourceLib/AboveGround/SimpleAsymmetricZOI/SimpleAsymmetricZOI.py
@@ -107,7 +107,7 @@ class SimpleAsymmetricZOI(ResourceModel):
             print("Error: mesh not fine enough for crown dimensions!")
             print(
                 "Please refine mesh or increase initial crown radius above " +
-                str(self.min_radius) + "m !")
+                str(self._mesh_size) + "m !")
             exit()
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the

--- a/ResourceLib/AboveGround/SimpleAsymmetricZOI/SimpleAsymmetricZOI.py
+++ b/ResourceLib/AboveGround/SimpleAsymmetricZOI/SimpleAsymmetricZOI.py
@@ -70,7 +70,8 @@ class SimpleAsymmetricZOI(ResourceModel):
     def getInputParameters(self, args):
         tags = {
             "prj_file": args,
-            "required": ["type", "domain", "x_1", "x_2", "y_1", "y_2", "x_resolution", "y_resolution"]
+            "required": ["type", "domain", "x_1", "x_2", "y_1", "y_2", "x_resolution", "y_resolution"],
+            "optional": ["allow_interpolation"]
         }
         super().getInputParameters(**tags)
         self._x_1 = self.x_1
@@ -79,6 +80,10 @@ class SimpleAsymmetricZOI(ResourceModel):
         self._y_2 = self.y_2
         self.x_resolution = int(self.x_resolution)
         self.y_resolution = int(self.y_resolution)
+        try:
+            self.allow_interpolation = eval(self.allow_interpolation)
+        except AttributeError:
+            pass
 
     ## This functions prepares arrays for the competition
     #  concept. In the SimpleAssymmetricZOI concept, plants geometric measures
@@ -102,13 +107,13 @@ class SimpleAsymmetricZOI(ResourceModel):
         x, y = plant.getPosition()
         geometry = plant.getGeometry()
         parameter = plant.getParameter()
-
         if geometry["r_crown"] < (self._mesh_size * 1 / 2**0.5):
-            print("Error: mesh not fine enough for crown dimensions!")
-            print(
-                "Please refine mesh or increase initial crown radius above " +
-                str(self._mesh_size) + "m !")
-            exit()
+            if not hasattr(self, "allow_interpolation") or not self.allow_interpolation:
+                print("Error: mesh not fine enough for crown dimensions!")
+                print(
+                    "Please refine mesh or increase initial crown radius above " +
+                    str(self._mesh_size) + "m !")
+                exit()
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the
                              domain, where AC is defined. Please check domains 

--- a/ResourceLib/AboveGround/SimpleAsymmetricZOI/SimpleAsymmetricZOI.py
+++ b/ResourceLib/AboveGround/SimpleAsymmetricZOI/SimpleAsymmetricZOI.py
@@ -55,7 +55,11 @@ class SimpleAsymmetricZOI(ResourceModel):
     #  @param crown_radius - crown radius (shape: (n_plants))\n
     #  @param distance - distance from the stem position(shape: (x_res, y_res))
     def calculateHeightFromDistance(self, stem_height, crown_radius, distance):
-        bools = crown_radius > distance
+        min_distance = np.min(distance)
+        # If root radius < mesh size, set it to mesh size
+        crown_radius[np.where(crown_radius < min_distance)] = min_distance
+
+        bools = crown_radius >= distance
         idx = np.where(bools)
         height = np.zeros_like(distance)
         #Here, the curved top of the plant is considered..
@@ -103,7 +107,7 @@ class SimpleAsymmetricZOI(ResourceModel):
             print("Error: mesh not fine enough for crown dimensions!")
             print(
                 "Please refine mesh or increase initial crown radius above " +
-                str(self._mesh_size) + "m !")
+                str(self.min_radius) + "m !")
             exit()
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the

--- a/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
+++ b/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
@@ -44,7 +44,7 @@ class SymmetricZOI(ResourceModel):
         if geometry["r_root"] < (self._mesh_size * 1 / 2**0.5):
             print("WARNING: mesh too course for below-ground module!")
             print("Please refine mesh or increase initial root radius above " +
-                  str(self.min_radius) + "m !")
+                  str(self._mesh_size) + "m !")
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the
                              domain, where BC is defined. Please check domains

--- a/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
+++ b/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
@@ -42,9 +42,11 @@ class SymmetricZOI(ResourceModel):
         x, y = plant.getPosition()
         geometry = plant.getGeometry()
         if geometry["r_root"] < (self._mesh_size * 1 / 2**0.5):
-            print("WARNING: mesh too course for below-ground module!")
-            print("Please refine mesh or increase initial root radius above " +
-                  str(self._mesh_size) + "m !")
+            if not hasattr(self, "allow_interpolation") or not self.allow_interpolation:
+                print("ERROR: mesh too course for below-ground module!")
+                print("Please refine mesh or increase initial root radius above " +
+                      str(self._mesh_size) + "m or allow interpolation.")
+                exit()
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the
                              domain, where BC is defined. Please check domains
@@ -92,7 +94,8 @@ class SymmetricZOI(ResourceModel):
     def getInputParameters(self, args):
         tags = {
             "prj_file": args,
-            "required": ["type", "domain", "x_1", "x_2", "y_1", "y_2", "x_resolution", "y_resolution"]
+            "required": ["type", "domain", "x_1", "x_2", "y_1", "y_2", "x_resolution", "y_resolution"],
+            "optional": ["allow_interpolation"]
         }
         super().getInputParameters(**tags)
         self._x_1 = self.x_1
@@ -101,3 +104,7 @@ class SymmetricZOI(ResourceModel):
         self._y_2 = self.y_2
         self.x_resolution = int(self.x_resolution)
         self.y_resolution = int(self.y_resolution)
+        try:
+            self.allow_interpolation = eval(self.allow_interpolation)
+        except AttributeError:
+            pass

--- a/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
+++ b/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
@@ -45,7 +45,7 @@ class SymmetricZOI(ResourceModel):
         if geometry["r_root"] < (self._mesh_size * 1 / 2**0.5):
             print("Error: mesh not fine enough for crown dimensions!")
             print("Please refine mesh or increase initial root radius above " +
-                  str(self._mesh_size) + "m !")
+                  str(self.min_r_root) + "m !")
             exit()
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the

--- a/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
+++ b/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
@@ -41,15 +41,13 @@ class SymmetricZOI(ResourceModel):
     def addPlant(self, plant):
         x, y = plant.getPosition()
         geometry = plant.getGeometry()
-
         if geometry["r_root"] < (self._mesh_size * 1 / 2**0.5):
-            print("Error: mesh not fine enough for crown dimensions!")
+            print("WARNING: mesh too course for below-ground module!")
             print("Please refine mesh or increase initial root radius above " +
-                  str(self.min_r_root) + "m !")
-            exit()
+                  str(self.min_radius) + "m !")
         if not ((self._x_1 < x < self._x_2) and (self._y_1 < y < self._y_2)):
             raise ValueError("""It appears as a plant is located outside of the
-                             domain, where BC is defined. Please check domains 
+                             domain, where BC is defined. Please check domains
                              in project file!!""")
         self.xe.append(x)
         self.ye.append(y)
@@ -64,10 +62,14 @@ class SymmetricZOI(ResourceModel):
                       np.array(self.xe)[np.newaxis, np.newaxis, :])**2 +
                      (self.my_grid[1][:, :, np.newaxis] -
                       np.array(self.ye)[np.newaxis, np.newaxis, :])**2)**0.5)
+        min_distance = np.min(distance)
+
         # Array of shape distance [res_x, res_y, n_plants], indicating which
         # cells are occupied by plant root plates
         root_radius = np.array(self.r_root)
-        plants_present = root_radius[np.newaxis, np.newaxis, :] > distance
+        # If root radius < mesh size, set it to mesh size
+        root_radius[np.where(root_radius < min_distance)] = min_distance
+        plants_present = root_radius[np.newaxis, np.newaxis, :] >= distance
 
         # Count all nodes, which are occupied by plants
         # returns array of shape [n_plants]
@@ -85,7 +87,6 @@ class SymmetricZOI(ResourceModel):
         for i in range(n_plants):
             plant_wins[i] = np.sum(plants_present_reci[np.where(
                 plants_present[:, :, i])])
-
         self.belowground_resources = plant_wins / plant_counts
 
     def getInputParameters(self, args):

--- a/ResourceLib/ResourceModel.py
+++ b/ResourceLib/ResourceModel.py
@@ -64,7 +64,6 @@ class ResourceModel:
             optional_tags = []
 
         for arg in prj_file_tags.iterdescendants():
-            print(arg)
             tag = arg.tag
             for i in range(0, len(required_tags)):
                 if tag == required_tags[i]:


### PR DESCRIPTION
(Require PR #273 and #269)

Here is a suggestion to avoid the dependence of the grid size on the minimum tree size.

Basically, we assign a small tree, which does not cross any grid node, to the next node.
Of course, this leads to different results if the grid is a course.

For symmetric ZOI (below-ground), differences are mainly apparent in the water uptake itself but not in tree size:
![compare_below](https://github.com/pymanga/pyMANGA/assets/48250781/b3569d83-a627-4cec-af77-bc00c7233d3c)

For asymmetric ZOI (above-ground), differences affect resource intake but also tree size, mainly of the smaller (shaded) tree.
![compare_above](https://github.com/pymanga/pyMANGA/assets/48250781/c26e8742-9a40-49f4-85d3-b6e2749dae6f)

@zaphod-bx @ChrisWudel Can you share your opinion on that?
@jack-w-hill consider this as info as you are going to use those modules soon :)

