### PR TITLE
New output function: range of time steps

### DIFF
--- a/Benchmarks/ExampleSetups/ExmouthGulf/setup_pymanga.xml
+++ b/Benchmarks/ExampleSetups/ExmouthGulf/setup_pymanga.xml
@@ -57,7 +57,7 @@
     </visualization>
     <output>
         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep> 1 </output_each_nth_timestep>
+        <output_each_nth_timestep> [1] </output_each_nth_timestep>
         <allow_previous_output>True</allow_previous_output>
         <output_dir> Benchmarks/ExampleSetups/ExmouthGulf/TreeOutput </output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ExampleSetups/ExternalSetup/ExternalOGS.xml
+++ b/Benchmarks/ExampleSetups/ExternalSetup/ExternalOGS.xml
@@ -45,7 +45,7 @@
     </visualization>
     <output>
         <type> OneTreeOneFile </type>
-        <output_each_nth_timestep> 1 </output_each_nth_timestep>
+        <output_each_nth_timestep> [1] </output_each_nth_timestep>
         <output_dir> Benchmarks/ExampleSetups/ExternalSetup/TreeOutput </output_dir>
         <allow_previous_output>True</allow_previous_output>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ExampleSetups/FixedSalinityFromFile/FixedSalinity_FromFile_A.xml
+++ b/Benchmarks/ExampleSetups/FixedSalinityFromFile/FixedSalinity_FromFile_A.xml
@@ -38,7 +38,7 @@
     </visualization>
     <output>
         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
+        <output_each_nth_timestep>[1]1</output_each_nth_timestep>
         <output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>

--- a/Benchmarks/ExampleSetups/FixedSalinityFromFile/FixedSalinity_FromFile_B.xml
+++ b/Benchmarks/ExampleSetups/FixedSalinityFromFile/FixedSalinity_FromFile_B.xml
@@ -38,7 +38,7 @@
     </visualization>
     <output>
         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
+        <output_each_nth_timestep>[1]1</output_each_nth_timestep>
         <output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>

--- a/Benchmarks/ExampleSetups/FixedSalinityFromFile/FixedSalinity_FromFile_C.xml
+++ b/Benchmarks/ExampleSetups/FixedSalinityFromFile/FixedSalinity_FromFile_C.xml
@@ -38,7 +38,7 @@
     </visualization>
     <output>
         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
+        <output_each_nth_timestep>[1]1</output_each_nth_timestep>
         <output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>

--- a/Benchmarks/ExampleSetups/ModelOutputOptions/OneFile.xml
+++ b/Benchmarks/ExampleSetups/ModelOutputOptions/OneFile.xml
@@ -1,0 +1,60 @@
+<MangaProject>
+    <random_seed>643879</random_seed>
+    <resources>
+        <aboveground>
+            <type> Default </type>
+        </aboveground>
+        <belowground>
+            <type> Default </type>
+        </belowground>
+    </resources>
+    <plant_dynamics>
+        <type> Bettina </type>
+        <mortality>NoGrowth</mortality>
+    </plant_dynamics>
+    <population>
+        <group>
+            <name> Species_1 </name>
+            <species> Benchmarks/ModuleBenchmarks/TreeOutput/species1.py </species>
+            <distribution>
+                <type> GroupFromFile </type>
+                <n_recruitment_per_step> 0 </n_recruitment_per_step>
+                <filename> Benchmarks/ModuleBenchmarks/TreeOutput/initial_population_1.csv </filename>
+            </distribution>
+        </group>
+        <group>
+            <name> Species_2 </name>
+            <species> Benchmarks/ModuleBenchmarks/TreeOutput/species2.py </species>
+            <distribution>
+                <type> GroupFromFile </type>
+                <n_recruitment_per_step> 0 </n_recruitment_per_step>
+                <filename> Benchmarks/ModuleBenchmarks/TreeOutput/initial_population_2.csv </filename>
+            </distribution>
+        </group>
+    </population>
+    <time_loop>
+        <type> Simple </type>
+        <t_start> 0 </t_start>
+        <t_end> 100 </t_end>
+        <delta_t> 1 </delta_t>
+    </time_loop>
+    <visualization>
+        <type> NONE </type>
+    </visualization>
+    <output>
+        <type> OneFile </type>
+        <output_each_nth_timestep> [20, 3] </output_each_nth_timestep>
+		<output_times> [23] </output_times>
+        <output_time_range> [80, 95] </output_time_range>
+        <allow_previous_output>True</allow_previous_output>
+        <output_dir>Benchmarks/TestOutputs/</output_dir>
+        <geometry_output> r_stem </geometry_output>
+        <geometry_output> h_stem </geometry_output>
+        <geometry_output> r_crown </geometry_output>
+        <geometry_output> r_root </geometry_output>
+        <growth_output> growth </growth_output>
+        <growth_output> ag_resources </growth_output>
+        <growth_output> bg_resources </growth_output>
+    </output>
+</MangaProject>
+

--- a/Benchmarks/ExampleSetups/OGSExampleSetup/NetwOGS3D_SAZOI_BETTINA.xml
+++ b/Benchmarks/ExampleSetups/OGSExampleSetup/NetwOGS3D_SAZOI_BETTINA.xml
@@ -54,7 +54,7 @@
     <output>
         <type>OnePlantOneFile</type>
         <allow_previous_output>True</allow_previous_output>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
+        <output_each_nth_timestep>[1]1</output_each_nth_timestep>
         <output_dir>Benchmarks/ExampleSetups/OGSExampleSetup/TreeOutputNetwork</output_dir>
         <geometry_output>r_stem</geometry_output>
         <geometry_output>h_stem</geometry_output>

--- a/Benchmarks/ExampleSetups/OGSExampleSetup/OGS3D_SAZOI_BETTINA.xml
+++ b/Benchmarks/ExampleSetups/OGSExampleSetup/OGS3D_SAZOI_BETTINA.xml
@@ -51,7 +51,7 @@
     <output>
         <type>OnePlantOneFile</type>
         <allow_previous_output>True</allow_previous_output>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
+        <output_each_nth_timestep>[1]</output_each_nth_timestep>
         <output_dir>Benchmarks/ExampleSetups/OGSExampleSetup/TreeOutput/</output_dir>
         <geometry_output>r_stem</geometry_output>
         <geometry_output>h_stem</geometry_output>

--- a/Benchmarks/GenericTests/AllSimple.xml
+++ b/Benchmarks/GenericTests/AllSimple.xml
@@ -55,7 +55,7 @@
     </visualization>
     <output>
         <type> OneTreeOneFile </type>
-        <output_each_nth_timestep> 1 </output_each_nth_timestep>
+        <output_each_nth_timestep> [1] </output_each_nth_timestep>
         <output_dir> Benchmarks/TestOutputs/ </output_dir>
         <geometry_output> r_stem </geometry_output>
         <geometry_output> h_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
@@ -41,9 +41,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
@@ -41,7 +41,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
@@ -41,7 +41,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
@@ -41,9 +41,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity.xml
@@ -36,7 +36,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity.xml
@@ -36,9 +36,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity_CI.xml
@@ -36,9 +36,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/FixedSalinity/FixedSalinity_CI.xml
@@ -36,7 +36,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D.xml
@@ -43,9 +43,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D.xml
@@ -43,7 +43,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D_CI.xml
@@ -43,9 +43,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/OGSLargeScale3D/OGSLargeScale3D_CI.xml
@@ -43,7 +43,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI.xml
@@ -41,7 +41,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI.xml
@@ -41,9 +41,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI_CI.xml
@@ -41,7 +41,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Belowground/SymmetricZOI/SymmetricZOI_CI.xml
@@ -41,9 +41,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default_CI.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/Default_CI.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/ReferenceTree.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/ReferenceTree.xml
@@ -39,9 +39,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <allow_previous_output>True</allow_previous_output>
+        <type> OneFile </type><allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>
         <geometry_output> h_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/ReferenceTree.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Default/ReferenceTree.xml
@@ -39,7 +39,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneFile </type><allow_previous_output>True</allow_previous_output>
+        <type> OneFile </type>
+		<allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>
         <geometry_output> h_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory.xml
@@ -35,7 +35,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory.xml
@@ -35,9 +35,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory_CI.xml
@@ -35,9 +35,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Memory/Memory_CI.xml
@@ -35,7 +35,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth_CI.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/NoGrowth/NoGrowth_CI.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random_CI.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/Random/Random_CI.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth_CI.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Bettina/Mortality/RandomGrowth/RandomGrowth_CI.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network.xml
@@ -36,7 +36,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network.xml
@@ -36,9 +36,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network_CI.xml
@@ -36,9 +36,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/Network/Network_CI.xml
@@ -36,7 +36,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity.xml
@@ -39,7 +39,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity.xml
@@ -39,9 +39,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity_CI.xml
@@ -39,9 +39,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkFixedSalinity/NetworkFixedSalinity_CI.xml
@@ -39,7 +39,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D.xml
@@ -46,7 +46,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D.xml
@@ -46,9 +46,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D_Cl.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D_Cl.xml
@@ -46,7 +46,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D_Cl.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/BettinaNetwork/Belowground/NetworkOGSLargeScale3D/NetworkOGSLargeScale3D_Cl.xml
@@ -46,9 +46,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
@@ -41,9 +41,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/ReferenceFiles/AsymmetricZOI</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI.xml
@@ -41,7 +41,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/ReferenceFiles/AsymmetricZOI</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
@@ -41,7 +41,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Aboveground/AsymmetricZOI/AsymmetricZOI_CI.xml
@@ -41,9 +41,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FON/FON_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FON/FON_CI.xml
@@ -44,7 +44,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FON/FON_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FON/FON_CI.xml
@@ -44,9 +44,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity.xml
@@ -36,7 +36,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/ReferenceFiles/FixedSalinity</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity.xml
@@ -36,9 +36,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/ReferenceFiles/FixedSalinity</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity_CI.xml
@@ -36,9 +36,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Belowground/FixedSalinity/FixedSalinity_CI.xml
@@ -36,7 +36,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/ReferenceFiles/Default</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/ReferenceFiles/Default</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default_CI.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Default/Default_CI.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory.xml
@@ -35,9 +35,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/ReferenceFiles/Memory</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory.xml
@@ -35,7 +35,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/ReferenceFiles/Memory</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory_CI.xml
@@ -35,9 +35,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Memory/Memory_CI.xml
@@ -35,7 +35,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/ReferenceFiles/NoGrowth</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/ReferenceFiles/NoGrowth</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth_CI.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/NoGrowth/NoGrowth_CI.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/ReferenceFiles/Random</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/ReferenceFiles/Random</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random_CI.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/Random/Random_CI.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/ReferenceFiles/RandomGrowth</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/ReferenceFiles/RandomGrowth</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth_CI.xml
@@ -34,9 +34,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/PlantModules/Kiwi/Mortality/RandomGrowth/RandomGrowth_CI.xml
@@ -34,7 +34,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile.xml
@@ -42,9 +42,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile.xml
@@ -42,7 +42,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile_CI.xml
@@ -42,7 +42,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneFile </type><output_times> [2e6] </output_times>
+         <type> OneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneFile/OneFile_CI.xml
@@ -42,9 +42,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+         <type> OneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile/OnePlantOneFile.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile/OnePlantOneFile.xml
@@ -35,16 +35,15 @@
     <time_loop>
         <type> Simple </type>
         <t_start> 0 </t_start>
-        <t_end> 5e8 </t_end>
-        <delta_t> 1e6 </delta_t>
+        <t_end> 10 </t_end>
+        <delta_t> 1 </delta_t>
     </time_loop>
     <visualization>
         <type> NONE </type>
     </visualization>
     <output>
          <type> OnePlantOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_time_range> [0, 5e8] </output_time_range>
+        <output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile/OnePlantOneFile.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile/OnePlantOneFile.xml
@@ -44,7 +44,7 @@
     <output>
          <type> OnePlantOneFile </type>
         <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+        <output_time_range> [0, 5e8] </output_time_range>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile/OnePlantOneFile_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile/OnePlantOneFile_CI.xml
@@ -43,7 +43,6 @@
     </visualization>
     <output>
         <type> OnePlantOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
         <output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OnePlantOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OnePlantOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OnePlantOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OnePlantOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2_CI.xml
@@ -33,7 +33,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OnePlantOneFile </type><output_times> [2e6] </output_times>
+        <type> OnePlantOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OnePlantOneFile_2/OnePlantOneFile_2_CI.xml
@@ -33,9 +33,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OnePlantOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OnePlantOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile.xml
@@ -42,9 +42,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile.xml
@@ -42,7 +42,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFile </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFile </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile_CI.xml
@@ -42,9 +42,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFile/OneTimestepOneFile_CI.xml
@@ -42,7 +42,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFile </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFile </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup.xml
@@ -42,7 +42,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFilePerGroup </type><output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFilePerGroup </type>
+		<output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup.xml
@@ -42,9 +42,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-         <type> OneTimestepOneFilePerGroup </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6, 5e8] </output_times>
+         <type> OneTimestepOneFilePerGroup </type><output_times> [2e6, 5e8] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup_CI.xml
@@ -42,7 +42,8 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFilePerGroup </type><output_times> [2e6] </output_times>
+        <type> OneTimestepOneFilePerGroup </type>
+		<output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup_CI.xml
+++ b/Benchmarks/ModuleBenchmarks/TreeOutput/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup_CI.xml
@@ -42,9 +42,7 @@
         <type> NONE </type>
     </visualization>
     <output>
-        <type> OneTimestepOneFilePerGroup </type>
-        <output_each_nth_timestep>1</output_each_nth_timestep>
-        <output_times> [2e6] </output_times>
+        <type> OneTimestepOneFilePerGroup </type><output_times> [2e6] </output_times>
         <allow_previous_output>True</allow_previous_output>
         <output_dir>Benchmarks/TestOutputs/</output_dir>
         <geometry_output> r_stem </geometry_output>

--- a/ModelOutputLib/ModelOutput.md
+++ b/ModelOutputLib/ModelOutput.md
@@ -1,0 +1,30 @@
+
+Attributes:
+    type (string): Name of output module (see notes).
+    output_each_nth_timestep (list): (optional) max. 2 numbers indicating in which timestep output is written. The first value refers to the time before and after ``output_time_range`` while the second number applies to `output_time_range`.
+    output_times (list): (optional) values indicate time step(s) to write output.
+    output_time_range (list): (optional) 2 values, indicating a time window where each step is written to the output file except a second value is defined for ``output_each_nth_timestep``.
+    ...
+
+Notes:
+    type **OneFile** write model output to 1 csv-file  
+    type **OnePlantOneFile**  ...
+
+Examples:
+    ````xml
+    <output>
+        <type> OneFile </type>
+        <output_each_nth_timestep> [20, 3] </output_each_nth_timestep>
+        <output_times> [23] </output_times>
+        <output_time_range> [80, 95] </output_time_range>
+        <allow_previous_output>True</allow_previous_output>
+        <output_dir>Benchmarks/TestOutputs/</output_dir>
+        <geometry_output> r_stem </geometry_output>
+        <geometry_output> h_stem </geometry_output>
+        <geometry_output> r_crown </geometry_output>
+        <geometry_output> r_root </geometry_output>
+        <growth_output> growth </growth_output>
+        <growth_output> ag_resources </growth_output>
+        <growth_output> bg_resources </growth_output>
+    </output>
+    ````

--- a/ModelOutputLib/ModelOutput.py
+++ b/ModelOutputLib/ModelOutput.py
@@ -33,10 +33,9 @@ class ModelOutput:
             allow_previous_output = False
         ## Check if specific timesteps for output are defined
         self.output_times = args.find("output_times")
-        self.output_time_range = args.find("output_time_range")
         if self.output_times is not None:
             self.output_times = eval(self.output_times.text)
-
+        self.output_time_range = args.find("output_time_range")
         if self.output_time_range is not None:
             self.output_time_range = eval(self.output_time_range.text)
             if len(self.output_time_range) != 2:
@@ -180,16 +179,22 @@ class ModelOutput:
             force_output (bool): indicate whether writing output is forced
             group_died (bool): indicate whether a whole plant group died
         """
+        self._it_is_output_time = False
+        self.cond1, self.cond2, self.cond3 = False, False, False
         if self.output_each_nth_timestep is not None:
             self._output_counter = (self._output_counter %
                                     self.output_each_nth_timestep)
-            self._it_is_output_time = (self._output_counter == 0)
+            self.cond1 = (self._output_counter == 0)
+
         if self.output_times is not None:
-            self._it_is_output_time = (time in self.output_times)
+            self.cond2 = (time in self.output_times)
         if self.output_time_range is not None:
-            self._it_is_output_time = (self.output_time_range[0] <=
+            self.cond3 = (self.output_time_range[0] <=
                                        time <=
                                        self.output_time_range[1])
+        if any([self.cond1, self.cond2, self.cond3]):
+            self._it_is_output_time = True
+
         if force_output or group_died:
             self._it_is_output_time = True
 
@@ -197,7 +202,6 @@ class ModelOutput:
             self.outputContent(plant_groups=plant_groups,
                                time=time,
                                group_died=group_died)
-            self._it_is_output_time = False
         self._output_counter += 1
 
     def outputContent(self, plant_groups, time, **kwargs):

--- a/ModelOutputLib/ModelOutput.py
+++ b/ModelOutputLib/ModelOutput.py
@@ -8,7 +8,7 @@ class ModelOutput:
     Parent class for all model output modules.
     """
 
-    def __init__(self, args):
+    def __init__(self, args, time):
         """
         Get relevant tags from project file and create output directory and/or file.
         Check if output file exists and can be overwritten.
@@ -32,11 +32,16 @@ class ModelOutput:
         else:
             allow_previous_output = False
         ## Check if specific timesteps for output are defined
-        output_times = args.find("output_times")
-        if output_times is not None:
-            self.output_times = eval(output_times.text)
-        else:
-            self.output_times = None
+        self.output_times = args.find("output_times")
+        self.output_time_range = args.find("output_time_range")
+        if self.output_times is not None:
+            self.output_times = eval(self.output_times.text)
+
+        if self.output_time_range is not None:
+            self.output_time_range = eval(self.output_time_range.text)
+            if len(self.output_time_range) != 2:
+                raise ValueError("The tag \'<output_time_range>\' in the xml file"
+                                 " caused an error. Please check your input!")
 
         ## Geometric measures included in output
         self.geometry_outputs = []
@@ -181,6 +186,10 @@ class ModelOutput:
             self._it_is_output_time = (self._output_counter == 0)
         if self.output_times is not None:
             self._it_is_output_time = (time in self.output_times)
+        if self.output_time_range is not None:
+            self._it_is_output_time = (self.output_time_range[0] <=
+                                       time <=
+                                       self.output_time_range[1])
         if force_output or group_died:
             self._it_is_output_time = True
 

--- a/ModelOutputLib/ModelOutput.py
+++ b/ModelOutputLib/ModelOutput.py
@@ -21,8 +21,12 @@ class ModelOutput:
         ## N-timesteps between two outputs
         self.output_each_nth_timestep = args.find("output_each_nth_timestep")
         if self.output_each_nth_timestep is not None:
-            self.output_each_nth_timestep = int(
-                self.checkRequiredKey("output_each_nth_timestep", args))
+            self.output_each_nth_timestep = eval(self.output_each_nth_timestep.text)
+            if len(self.output_each_nth_timestep) == 1:
+                self.output_each_nth_timestep.append(1)
+            elif len(self.output_each_nth_timestep) > 2:
+                raise ValueError("The tag \'<output_each_nth_timestep>\' in the xml file"
+                                 " caused an error. Please check your input!")
         else:
             self.output_each_nth_timestep = None
         ## Check if overwrite of previous output is allowed
@@ -52,6 +56,8 @@ class ModelOutput:
         self.network_outputs = []
         ## Counter for output generation
         self._output_counter = 0
+        self._output_counter2 = 0
+
         for key in args.iterchildren("geometry_output"):
             self.geometry_outputs.append(key.text.strip())
         for key in args.iterchildren("parameter_output"):
@@ -143,9 +149,6 @@ class ModelOutput:
                     growth_information[growth_output_key] = "NaN"
                     string += delimiter + str(
                         growth_information[growth_output_key])
-                    # print("Key " + growth_output_key +
-                    #       " might be not available in growth " + "concept!" +
-                    #       " Please read growth concept documentation.")
         if len(self.network_outputs) > 0:
             network = plant.getNetwork()
             for network_output in self.network_outputs:
@@ -180,18 +183,36 @@ class ModelOutput:
             group_died (bool): indicate whether a whole plant group died
         """
         self._it_is_output_time = False
-        self.cond1, self.cond2, self.cond3 = False, False, False
+        self.cond1, self.cond2, self.cond3, self.cond3a, self.cond3b = False, False, False, False, False
+        # Condition whether we are in the n-th timestep
         if self.output_each_nth_timestep is not None:
-            self._output_counter = (self._output_counter %
-                                    self.output_each_nth_timestep)
-            self.cond1 = (self._output_counter == 0)
-
+            if int(self.output_each_nth_timestep[0]) == 1:
+                self.cond1 = True
+            else:
+                self._output_counter = (self._output_counter %
+                                        int(self.output_each_nth_timestep[0]))
+                self.cond1 = (self._output_counter == 1)
+        # Condition whether we are in a certain output time
         if self.output_times is not None:
             self.cond2 = (time in self.output_times)
+        # Condition whether we are in the output time range
         if self.output_time_range is not None:
-            self.cond3 = (self.output_time_range[0] <=
+            self.cond3a = (self.output_time_range[0] <=
                                        time <=
                                        self.output_time_range[1])
+            # Condition whether we are in the n-th timestep
+            if self.output_each_nth_timestep is not None:
+                if int(self.output_each_nth_timestep[1]) == 1:
+                    self.cond3b = True
+                else:
+                    self._output_counter2 = (self._output_counter2 %
+                                            int(self.output_each_nth_timestep[1]))
+                    self.cond3b = (self._output_counter2 == 1)
+            else:
+                self.cond3b = True
+            self.cond3 = all([self.cond3a, self.cond3b])
+
+        # Check whether one of the above conditions is fulfilled
         if any([self.cond1, self.cond2, self.cond3]):
             self._it_is_output_time = True
 
@@ -203,6 +224,7 @@ class ModelOutput:
                                time=time,
                                group_died=group_died)
         self._output_counter += 1
+        self._output_counter2 = self._output_counter
 
     def outputContent(self, plant_groups, time, **kwargs):
         """

--- a/ModelOutputLib/NONE/NONE.py
+++ b/ModelOutputLib/NONE/NONE.py
@@ -4,7 +4,7 @@ from ModelOutputLib.ModelOutput import ModelOutput
 
 
 class NONE(ModelOutput):
-    def __init__(self, args):
+    def __init__(self, args, time):
         """
         Dummy class to avoid writing model output.
         Args:

--- a/ModelOutputLib/OneFile/OneFile.py
+++ b/ModelOutputLib/OneFile/OneFile.py
@@ -6,7 +6,7 @@ from ModelOutputLib.ModelOutput import ModelOutput
 
 class OneFile(ModelOutput):
 
-    def __init__(self, args):
+    def __init__(self, args, time):
         """
         Model output concept.
         Create a single file for all model output.
@@ -14,7 +14,7 @@ class OneFile(ModelOutput):
         Args:
             args: module specifications from project file tags
         """
-        super().__init__(args)
+        super().__init__(args, time)
 
         self.delimiter = "\t"
         self.createFileWithHeader(filename='Population.csv')

--- a/ModelOutputLib/OnePlantOneFile/OnePlantOneFile.py
+++ b/ModelOutputLib/OnePlantOneFile/OnePlantOneFile.py
@@ -5,7 +5,7 @@ import os
 
 
 class OnePlantOneFile(ModelOutput):
-    def __init__(self, args):
+    def __init__(self, args, time):
         """
         Model output concept.
         Create one file for each plant, i.e., a plant's progress is stored in a file.
@@ -14,7 +14,7 @@ class OnePlantOneFile(ModelOutput):
         Args:
             args: module specifications from project file tags
         """
-        super().__init__(args)
+        super().__init__(args, time)
         for path in os.listdir(self.output_dir):
             full_path = os.path.join(self.output_dir, path)
             if os.path.isfile(full_path):

--- a/ModelOutputLib/OneTimestepOneFile/OneTimestepOneFile.py
+++ b/ModelOutputLib/OneTimestepOneFile/OneTimestepOneFile.py
@@ -5,7 +5,7 @@ import os
 
 
 class OneTimestepOneFile(ModelOutput):
-    def __init__(self, args):
+    def __init__(self, args, time):
         """
         Model output concept.
         Create one file for each time step, i.e., each file contains the complete population of a single time step.
@@ -14,7 +14,7 @@ class OneTimestepOneFile(ModelOutput):
         Args:
             args: module specifications from project file tags
         """
-        super().__init__(args)
+        super().__init__(args, time)
 
     def outputContent(self, plant_groups, time, **kwargs):
         delimiter = "\t"

--- a/ModelOutputLib/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup.py
+++ b/ModelOutputLib/OneTimestepOneFilePerGroup/OneTimestepOneFilePerGroup.py
@@ -6,7 +6,7 @@ import os
 
 
 class OneTimestepOneFilePerGroup(OneTimestepOneFile):
-    def __init__(self, args):
+    def __init__(self, args, time):
         """
         Model output concept.
         Create one file per group for each time step, i.e., each file contains plants of one group for each time step.
@@ -15,7 +15,7 @@ class OneTimestepOneFilePerGroup(OneTimestepOneFile):
         Args:
             args: module specifications from project file tags
         """
-        super().__init__(args)
+        super().__init__(args, time)
 
     def outputContent(self, plant_groups, time, **kwargs):
         delimiter = "\t"

--- a/ModelOutputLib/__init__.py
+++ b/ModelOutputLib/__init__.py
@@ -2,6 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 Library of model output modules.
+
+.. include:: ./ModelOutput.md
+
 """
 
 from .ModelOutput import ModelOutput

--- a/ProjectLib/Project.py
+++ b/ProjectLib/Project.py
@@ -196,6 +196,7 @@ class MangaProject:
             class
         """
         arg = self.args["model_output"]
+        time = self.args["time_loop"]
         case = arg.find("type").text
         if case == "NONE":
             from ModelOutputLib.NONE import NONE as createOut
@@ -213,7 +214,7 @@ class MangaProject:
         print(case + " model output successfully initiated.")
 
         ## Containing configuration on model_output
-        self.model_output_concept = createOut(arg)
+        self.model_output_concept = createOut(arg, time)
 
     def getModelOutputConcept(self):
         """


### PR DESCRIPTION
A new tag in the xml file can be used to specify an interval of time steps in which output should be written. The synthax with ':' (e.g. [5:8] or [:8]) was unfortunately not so easy to implement. Because of the less complex variant for people who have no idea about indexing in programming languages the syntax for the new tag is:
<output_time_range> [<start_time>, <end_time>] </output_time_range>.