### PR TITLE
Console output restructure

### DIFF
--- a/MANGA.py
+++ b/MANGA.py
@@ -70,14 +70,14 @@ def main(argv):
     except UnboundLocalError:
         raise UnboundLocalError('Wrong usage of pyMANGA. Type "python' +
                                 ' main.py -h" for additional help.')
-    print("MANGA started at", t_start)
-    print('Running pyMANGA project', project_file)
+    print("--------------------\npyMANGA started at", t_start)
+    print('Running pyMANGA project file:', project_file)
     time_stepper = DynamicTimeStep(prj)
     prj.runProject(time_stepper)
     t_end = datetime.datetime.now()
-    print('pyMANGA project', project_file, ' successfully evaluated.')
-    print("MANGA finished at", t_end)
-    print("Total execution took", (t_end - t_start).seconds, " seconds")
+    print('pyMANGA project', project_file, 'successfully evaluated.')
+    print("pyMANGA finished at", t_end)
+    print("Total execution took", (t_end - t_start).seconds, "seconds")
 
 
 if __name__ == "__main__":

--- a/MANGA.py
+++ b/MANGA.py
@@ -12,7 +12,6 @@ from ProjectLib import XMLtoProject
 from TimeLoopLib import DynamicTimeStep
 import datetime
 
-
 class Model():
     ## Class to run the model from other programs
     #  @param project_file: path to pymanga project file.
@@ -55,6 +54,7 @@ def main(argv):
         print("""pyMANGA wrong usage. Type "python main.py -h"
   for additional help.""")
         sys.exit(0)
+    log_flag = False
     for opt, arg in opts:
         if opt == '-h':
             print("""pyMANGA arguments:
@@ -62,6 +62,26 @@ def main(argv):
             sys.exit()
         elif opt in ("-i", "--project_file"):
             project_file = str(arg)
+        elif opt in ("-l", "--logging"):
+            log_flag = True
+    
+    if log_flag:
+        # Duplicate output stream (logfile) back to stdout for console output
+        class DualOutput:
+            def __init__(self, *outputs):
+                self.outputs = outputs
+
+            def write(self, text):
+                for output in self.outputs:
+                    output.write(text)
+
+            def flush(self):
+                for output in self.outputs:
+                    output.flush()
+        file_output = open('logfile.log', 'wt')
+        dual_output = DualOutput(file_output, sys.stdout)
+        sys.stdout = dual_output
+
     t_start = datetime.datetime.now()
 
     try:

--- a/ModelOutputLib/ModelOutput.py
+++ b/ModelOutputLib/ModelOutput.py
@@ -80,11 +80,7 @@ class ModelOutput:
 
         self._it_is_output_time = True
         print(
-            "Output file can be found here: " + os.path.join(os.getcwd(), self.output_dir) + "\n" +
-            "The output file contains the parameters ", 
-            self.parameter_outputs, " and the geometric measures ",
-            self.geometry_outputs, " at every " +
-            str(self.output_each_nth_timestep) + " timesteps initialized.")
+            "Output file path: " + os.path.join(os.getcwd(), self.output_dir))
 
     def getOutputType(self):
         """

--- a/ModelOutputLib/ModelOutput.py
+++ b/ModelOutputLib/ModelOutput.py
@@ -80,9 +80,9 @@ class ModelOutput:
 
         self._it_is_output_time = True
         print(
-            "Output to '" + os.path.join(os.getcwd(), self.output_dir) +
-            "' of plant positions, the " + "parameters ",
-            self.parameter_outputs, " and geometric" + " measures ",
+            "Output file can be found here: " + os.path.join(os.getcwd(), self.output_dir) + "\n" +
+            "The output file contains the parameters ", 
+            self.parameter_outputs, " and the geometric measures ",
             self.geometry_outputs, " at every " +
             str(self.output_each_nth_timestep) + " timesteps initialized.")
 

--- a/PlantModelLib/Bettina/Bettina.py
+++ b/PlantModelLib/Bettina/Bettina.py
@@ -12,7 +12,7 @@ class Bettina(PlantModel):
             args: Bettina module specifications from project file tags
         """
         case = args.find("vegetation_model_type").text
-        print("Growth and death dynamics of type " + case + ".")
+        print("Initiate dynamic concept of type {}...".format(case))
         super().iniMortalityConcept(args)
 
     def prepareNextTimeStep(self, t_ini, t_end):

--- a/PlantModelLib/Bettina/Bettina.py
+++ b/PlantModelLib/Bettina/Bettina.py
@@ -12,7 +12,6 @@ class Bettina(PlantModel):
             args: Bettina module specifications from project file tags
         """
         case = args.find("vegetation_model_type").text
-        print("Initiate dynamic concept of type {}...".format(case))
         super().iniMortalityConcept(args)
 
     def prepareNextTimeStep(self, t_ini, t_end):

--- a/PlantModelLib/Default/Default.py
+++ b/PlantModelLib/Default/Default.py
@@ -15,7 +15,6 @@ class Default(ResourceModel):
         #  @param: Tags to define Default: type
         #  @date: 2019 - Today
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
 
     def prepareNextTimeStep(self, t_ini, t_end):
         ## This functions prepares the cgrowth and death concept.

--- a/PlantModelLib/Kiwi/Kiwi.py
+++ b/PlantModelLib/Kiwi/Kiwi.py
@@ -14,7 +14,6 @@ class Kiwi(PlantModel):
     #  @date 2019 - Today
     def __init__(self, args):
         case = args.find("vegetation_model_type").text
-        print("Growth and death dynamics of type " + case + ".")
         super().iniMortalityConcept(args)
 
     ## This functions prepares the growth and death concept.

--- a/PlantModelLib/Mortality/Mortality.py
+++ b/PlantModelLib/Mortality/Mortality.py
@@ -36,7 +36,7 @@ class Mortality:
                 raise KeyError("Required mortality not implemented. "
                                "Available concepts: `NoGrowth`, `Random`, "
                                "`RandomGrowth`, `Memory`")
-            print("Mortality concept set to {}.".format(case))
+            print("Plant mortality: {}.".format(case))
 
     def iniNoGrowth(self, args, case):
         """

--- a/PlantModelLib/Mortality/Mortality.py
+++ b/PlantModelLib/Mortality/Mortality.py
@@ -36,8 +36,7 @@ class Mortality:
                 raise KeyError("Required mortality not implemented. "
                                "Available concepts: `NoGrowth`, `Random`, "
                                "`RandomGrowth`, `Memory`")
-            print("Mortality concept of type " + case + " successfully "
-                  "initiated.")
+            print("Mortality concept set to {}.".format(case))
 
     def iniNoGrowth(self, args, case):
         """

--- a/PlantModelLib/Mortality/NoGrowth/NoGrowth.py
+++ b/PlantModelLib/Mortality/NoGrowth/NoGrowth.py
@@ -11,7 +11,7 @@ class NoGrowth:
             args: module specification from project file tags. No required.
             case: "NoGrowth" (module name)
         """
-        print("Initiate mortality of type `" + case + "`.")
+        print("Initiate mortality concept of type {}...".format(case))
 
     def setSurvive(self, plant_module):
         """

--- a/PlantModelLib/Mortality/NoGrowth/NoGrowth.py
+++ b/PlantModelLib/Mortality/NoGrowth/NoGrowth.py
@@ -11,7 +11,6 @@ class NoGrowth:
             args: module specification from project file tags. No required.
             case: "NoGrowth" (module name)
         """
-        print("Initiate mortality concept of type {}...".format(case))
 
     def setSurvive(self, plant_module):
         """

--- a/PopulationLib/GroupPlanting.py
+++ b/PopulationLib/GroupPlanting.py
@@ -130,6 +130,8 @@ class GroupPlanting(PlantGroup):
         self.l_x = max_x - self.x_1
         self.l_y = max_y - self.y_1
 
+        print("Plant population initialised and planted.")
+
     ## Randomly recruiting plants within given domain.
     def recruitPlants(self):
         for i in range(self.n_recruitment_per_step):

--- a/PopulationLib/GroupPlanting.py
+++ b/PopulationLib/GroupPlanting.py
@@ -28,9 +28,9 @@ class GroupPlanting(PlantGroup):
 
         distribution = self.tags_group.find("distribution")
         distribution_type = distribution.find("type").text
-        print("Plant group set to {}.".format(self.name) +
-              "\nDistribution type set to {}.".format(distribution_type) +
-              "\nSpecies set to {}.".format(self.species))
+        print("Plant group name: {}.".format(self.name) +
+              "\nDistribution type: {}.".format(distribution_type) +
+              "\nSpecies: {}.".format(self.species))
         if distribution_type == "Random":
             self.plantRandomDistributedPlants()
         elif distribution_type == "GroupFromFile":
@@ -130,7 +130,6 @@ class GroupPlanting(PlantGroup):
         self.l_x = max_x - self.x_1
         self.l_y = max_y - self.y_1
 
-        print("Plant population initialised and planted.")
 
     ## Randomly recruiting plants within given domain.
     def recruitPlants(self):

--- a/PopulationLib/GroupPlanting.py
+++ b/PopulationLib/GroupPlanting.py
@@ -28,9 +28,9 @@ class GroupPlanting(PlantGroup):
 
         distribution = self.tags_group.find("distribution")
         distribution_type = distribution.find("type").text
-        print("Initialise plant group " + self.name + " with " +
-              distribution_type + " distribution type and plants of species " +
-              self.species + ".")
+        print("Plant group set to {}.".format(self.name) +
+              "\nDistribution type set to {}.".format(distribution_type) +
+              "\nSpecies set to {}.".format(self.species))
         if distribution_type == "Random":
             self.plantRandomDistributedPlants()
         elif distribution_type == "GroupFromFile":

--- a/ProjectLib/Project.py
+++ b/ProjectLib/Project.py
@@ -223,7 +223,7 @@ class MangaProject:
         else:
             raise KeyError("Required model_output of type '" + case +
                            "' not implemented!")
-        print(case + " model output successfully initiated.")
+        print("Model output set to {}.".format(case))
 
         ## Containing configuration on model_output
         self.model_output_concept = createOut(arg, time)

--- a/ProjectLib/Project.py
+++ b/ProjectLib/Project.py
@@ -52,7 +52,7 @@ class MangaProject:
         if self.args["random_seed"] is not None:
             _seed = int(self.args["random_seed"].text.strip())
             np.random.seed(_seed)
-            print("Seed set to {}.".format(_seed))
+            print("Random Seed: {}.".format(_seed))
 
     def iniBelowgroundResourceConcept(self):
         """
@@ -94,7 +94,7 @@ class MangaProject:
             raise KeyError("Required below-ground competition case " + case +
                            " not implemented.")
         self.belowground_resource_concept = createBC(arg)
-        print("Belowground competition set to {}.".format(case))
+        print("Below-ground resources: {}.".format(case))
 
     def getAbovegroundResourceConcept(self):
         """
@@ -119,7 +119,7 @@ class MangaProject:
         else:
             raise KeyError("Required above-ground competition not implemented.")
         self.aboveground_resource_concept = createAC(arg)
-        print("Aboveground competition set to {}.".format(case))
+        print("Above-ground resources: {}.".format(case))
 
     def getPlantDynamicConcept(self):
         """
@@ -148,7 +148,7 @@ class MangaProject:
         else:
             raise KeyError("Required plant dynamic concept not implemented.")
         self.plant_dynamic_concept = createGD(arg)
-        print("Plant dynamic concept set to {}.".format(case))
+        print("Plant growth: {}.".format(case))
 
     def iniPopulationConcept(self):
         """
@@ -223,7 +223,7 @@ class MangaProject:
         else:
             raise KeyError("Required model_output of type '" + case +
                            "' not implemented!")
-        print("Model output set to {}.".format(case))
+        print("Model output: {}.".format(case))
 
         ## Containing configuration on model_output
         self.model_output_concept = createOut(arg, time)

--- a/ProjectLib/Project.py
+++ b/ProjectLib/Project.py
@@ -4,6 +4,7 @@ from VisualizationLib import Visualization
 import PopulationLib
 from TimeLoopLib import DynamicTimeLoop
 import numpy as np
+import datetime
 
 
 class MangaProject:
@@ -16,6 +17,7 @@ class MangaProject:
         Sets:
             multiple dictionaries
         """
+        self.iniInitiation()
         self.iniNumpyRandomSeed()
         self.iniAbovegroundResourceConcept()
         self.iniBelowgroundResourceConcept()
@@ -31,15 +33,26 @@ class MangaProject:
             class
         """
         return self.belowground_resource_concept
+    
+    def iniInitiation(self):
+        """
+        Initiate pyMANGA simulation.
+        """
+        print("Running pyMANGA v2.0.0 - ", 
+              datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+              "\n==============================================",
+              "\nSimulation Settings:",
+              "\n--------------------")
+        
 
     def iniNumpyRandomSeed(self):
         """
         Set random seed.
         """
         if self.args["random_seed"] is not None:
-            print("Setting seed for random number generator.")
             _seed = int(self.args["random_seed"].text.strip())
             np.random.seed(_seed)
+            print("Seed set to {}.".format(_seed))
 
     def iniBelowgroundResourceConcept(self):
         """
@@ -81,7 +94,7 @@ class MangaProject:
             raise KeyError("Required below-ground competition case " + case +
                            " not implemented.")
         self.belowground_resource_concept = createBC(arg)
-        print(case + " below-ground competition successfully initiated.")
+        print("Belowground competition set to {}.".format(case))
 
     def getAbovegroundResourceConcept(self):
         """
@@ -106,7 +119,7 @@ class MangaProject:
         else:
             raise KeyError("Required above-ground competition not implemented.")
         self.aboveground_resource_concept = createAC(arg)
-        print(case + " above-ground competition successfully initiated.")
+        print("Aboveground competition set to {}.".format(case))
 
     def getPlantDynamicConcept(self):
         """
@@ -135,7 +148,7 @@ class MangaProject:
         else:
             raise KeyError("Required plant dynamic concept not implemented.")
         self.plant_dynamic_concept = createGD(arg)
-        print(case + " plant dynamic concept initiated.")
+        print("Plant dynamic concept set to {}.".format(case))
 
     def iniPopulationConcept(self):
         """

--- a/ResourceLib/AboveGround/AsymmetricZOI/AsymmetricZOI.py
+++ b/ResourceLib/AboveGround/AsymmetricZOI/AsymmetricZOI.py
@@ -16,7 +16,6 @@ class AsymmetricZOI(ResourceModel):
     #  @date: 2019 - Today
     def __init__(self, args):
         case = args.find("type").text
-        print("Initiate aboveground competition of type " + case + ".")
         self.getInputParameters(args)
         super().makeGrid()
 

--- a/ResourceLib/AboveGround/Default/Default.py
+++ b/ResourceLib/AboveGround/Default/Default.py
@@ -15,7 +15,6 @@ class Default(ResourceModel):
         #  @param: Tags to define Default: type
         #  @date: 2019 - Today
         case = args.find("type").text
-        print("Initiate aboveground competition of type " + case + "...")
 
     def calculateAbovegroundResources(self):
         ## This function returns the AbovegroundResources calculated in the

--- a/ResourceLib/AboveGround/Default/Default.py
+++ b/ResourceLib/AboveGround/Default/Default.py
@@ -15,7 +15,7 @@ class Default(ResourceModel):
         #  @param: Tags to define Default: type
         #  @date: 2019 - Today
         case = args.find("type").text
-        print("Initiate aboveground competition of type " + case + ".")
+        print("Initiate aboveground competition of type " + case + "...")
 
     def calculateAbovegroundResources(self):
         ## This function returns the AbovegroundResources calculated in the

--- a/ResourceLib/BelowGround/Generic/Merge/Merge.py
+++ b/ResourceLib/BelowGround/Generic/Merge/Merge.py
@@ -10,7 +10,6 @@ class Merge(ResourceModel):
             args: Merge module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
 
         try:
             modules = args.find("modules").text

--- a/ResourceLib/BelowGround/Individual/Default/Default.py
+++ b/ResourceLib/BelowGround/Individual/Default/Default.py
@@ -11,7 +11,6 @@ class Default(ResourceModel):
             args: FixedSalinity module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
 
     def prepareNextTimeStep(self, t_ini, t_end):
         self.plants = []

--- a/ResourceLib/BelowGround/Individual/FON/FON.py
+++ b/ResourceLib/BelowGround/Individual/FON/FON.py
@@ -12,7 +12,6 @@ class FON(ResourceModel):
             args: FON module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
         self.getInputParameters(args)
         super().makeGrid()
         if self._mesh_size > 0.25:

--- a/ResourceLib/BelowGround/Individual/FixedSalinity/FixedSalinity.py
+++ b/ResourceLib/BelowGround/Individual/FixedSalinity/FixedSalinity.py
@@ -13,7 +13,6 @@ class FixedSalinity(ResourceModel):
             args: FixedSalinity module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + "...")
         self.variant = None
         self.getInputParameters(args)
 

--- a/ResourceLib/BelowGround/Individual/FixedSalinity/FixedSalinity.py
+++ b/ResourceLib/BelowGround/Individual/FixedSalinity/FixedSalinity.py
@@ -13,7 +13,7 @@ class FixedSalinity(ResourceModel):
             args: FixedSalinity module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
+        print("Initiate belowground competition of type " + case + "...")
         self.variant = None
         self.getInputParameters(args)
 
@@ -141,19 +141,12 @@ class FixedSalinity(ResourceModel):
                 # Two constant values over time for seaward and
                 # landward salinity
                 if len(arg.text.split()) == 2:
-                    print("In the control file, two values were given for " +
-                          "salinity at two given position values." +
-                          " These are constant over time and are linearly " +
-                          "interpolated using the provided points S(x).")
                     self._salinity = arg.text.split()
                     self._salinity[0] = float(self._salinity[0])
                     self._salinity[1] = float(self._salinity[1])
 
                 # Path to a file containing salinity values that vary over time
                 elif os.path.exists(arg.text) is True:
-                    print('In the control file a path to a file with ' +
-                          'values of the salt concentration over time was ' +
-                          'found.')
 
                     # Reading salinity values from a csv-file
                     self._salinity_over_t = np.loadtxt(

--- a/ResourceLib/BelowGround/Individual/OGS/OGS.py
+++ b/ResourceLib/BelowGround/Individual/OGS/OGS.py
@@ -24,7 +24,6 @@ class OGS(ResourceModel):
     def __init__(self, args):
         self.case = args.find("type").text
         self._abiotic_drivers = args.find("abiotic_drivers")
-        print("Initiate belowground competition of type " + self.case + ".")
         self._ogs_project_folder = args.find("ogs_project_folder").text.strip()
         if not path.isabs(self._ogs_project_folder):
             self._ogs_project_folder = \

--- a/ResourceLib/BelowGround/Individual/SZoiFixedSalinity/SZoiFixedSalinity.py
+++ b/ResourceLib/BelowGround/Individual/SZoiFixedSalinity/SZoiFixedSalinity.py
@@ -16,7 +16,6 @@ class SZoiFixedSalinity(SymmetricZOI, FixedSalinity):
     #  @date: 2020 - Today
     def __init__(self, args):
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
         super().makeGrid(args=args)
         self.getInputParameters(args=args)
 

--- a/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
+++ b/ResourceLib/BelowGround/Individual/SymmetricZOI/SymmetricZOI.py
@@ -19,7 +19,6 @@ class SymmetricZOI(ResourceModel):
     #  @date: 2019 - Today
     def __init__(self, args):
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
         self.getInputParameters(args)
         super().makeGrid()
 

--- a/ResourceLib/BelowGround/Network/Network/Network.py
+++ b/ResourceLib/BelowGround/Network/Network/Network.py
@@ -12,7 +12,6 @@ class Network(ResourceModel):
             args (lxml.etree._Element): Network module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate below-ground competition of type " + case + ".")
         self.getInputParameters(args=args)
 
     def prepareNextTimeStep(self, t_ini, t_end):

--- a/ResourceLib/BelowGround/Network/NetworkFixedSalinity/NetworkFixedSalinity.py
+++ b/ResourceLib/BelowGround/Network/NetworkFixedSalinity/NetworkFixedSalinity.py
@@ -13,7 +13,6 @@ class NetworkFixedSalinity(Network, FixedSalinity):
             args: NetworkFixedSalinity module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate belowground competition of type " + case + ".")
         self.getInputParameters(args=args)
 
     def prepareNextTimeStep(self, t_ini, t_end):

--- a/TimeLoopLib/DynamicTimeLoop.py
+++ b/TimeLoopLib/DynamicTimeLoop.py
@@ -24,8 +24,6 @@ class DynamicTimeLoop:
         except:
             self.terminal_print = False
 
-        print(case + " time stepping successfully initiated.")
-
     def iniSimpleTimeStepping(self, args):
         """
         Initialize time stepping of type "Default".

--- a/TimeLoopLib/SimpleLoop/SimpleLoop.py
+++ b/TimeLoopLib/SimpleLoop/SimpleLoop.py
@@ -12,7 +12,7 @@ class SimpleLoop:
             args: module specifications from project file tags
         """
         case = args.find("type").text
-        print("Time loop set to {}.".format(case))
+        print("Time loop: {}.".format(case))
         self.t_start = float(args.find("t_start").text)
         self.t_end = float(args.find("t_end").text)
         self.t_2 = self.t_start

--- a/TimeLoopLib/SimpleLoop/SimpleLoop.py
+++ b/TimeLoopLib/SimpleLoop/SimpleLoop.py
@@ -12,7 +12,7 @@ class SimpleLoop:
             args: module specifications from project file tags
         """
         case = args.find("type").text
-        print("Initiate time loop of type " + case + ".")
+        print("Time loop set to {}.".format(case))
         self.t_start = float(args.find("t_start").text)
         self.t_end = float(args.find("t_end").text)
         self.t_2 = self.t_start

--- a/VisualizationLib/NONE/NONE.py
+++ b/VisualizationLib/NONE/NONE.py
@@ -11,7 +11,6 @@ class NONE(Visualization):
     ## Constructor of dummy objects in order to drop visualization
     def __init__(self, args):
         self.case = args.find("type").text
-        print("Running without visualization.")
 
     ## Dummy update function
     def update(self, plant_groups, time):

--- a/VisualizationLib/SimplePyplot/SimplePyplot.py
+++ b/VisualizationLib/SimplePyplot/SimplePyplot.py
@@ -17,7 +17,6 @@ class SimplePyplot(Visualization):
     def __init__(self, args):
         self.case = args.find("type").text
 
-        print("Initiate visualization of type " + self.case + ".")
         try:
             self._max_fps = float(args.find("max_fps").text)
         except AttributeError:

--- a/VisualizationLib/Visualization.py
+++ b/VisualizationLib/Visualization.py
@@ -16,11 +16,11 @@ class Visualization:
         if self.case == "SimplePyplot":
             self.iniSimplePyplot(args)
         elif self.case == "NONE":
-            self.case = "No"
+            self.case = "NONE"
             self.iniNONE(args)
         else:
             raise KeyError("Required visualization type not implemented.")
-        print(self.case + " visualization successfully initiated.")
+        print("Visualization set to {}.".format(self.case))
 
     ## Initiatiates visualization of type Pyplot
     def iniSimplePyplot(self, args):

--- a/VisualizationLib/Visualization.py
+++ b/VisualizationLib/Visualization.py
@@ -20,7 +20,7 @@ class Visualization:
             self.iniNONE(args)
         else:
             raise KeyError("Required visualization type not implemented.")
-        print("Visualization set to {}.".format(self.case))
+        print("Visualization: {}.".format(self.case))
 
     ## Initiatiates visualization of type Pyplot
     def iniSimplePyplot(self, args):


### PR DESCRIPTION
Reworked console output to eliminate redundant messages and improve structure.
This was requested in #226 

The most recent commit also introduces an argument (`-l, --logging`) to create a log file that contains all outputs (e.g. `print()` statements) from the current pyMANGA execution. 

I also tried the `logging` package. While I was able to redirect the output to a logfile using `logging`. I was not able to find a solution to write the output to console and file simultaneously.