### PR TITLE
Curved crown in AZOI

### DIFF
--- a/ResourceLib/AboveGround/AsymmetricZOI/AsymmetricZOI.md
+++ b/ResourceLib/AboveGround/AsymmetricZOI/AsymmetricZOI.md
@@ -37,6 +37,8 @@ There is no temporal variation in light availability.
     - ``y_resolution`` (float): y-resolution of the grid
 - ``allow_interpolation`` (bool): (optional) If True, the ZOI of a plant can be smaller than a grid cell, and it will be
   assigned to the nearest node. Default: False.
+- ``curved_crown`` (bool): (optional) If True, a curve-shaped crown is assumed. See pyMANGAs <a href="https://github.com/pymanga/sensitivity/blob/main/ResourceLib/AboveGround/AsymmetricZOI/curved_crown/curved_crown.md" target="_blank">sensetivity repository</a> for more information. Default: True
+
 
 # Value
 

--- a/ResourceLib/AboveGround/AsymmetricZOI/AsymmetricZOI.py
+++ b/ResourceLib/AboveGround/AsymmetricZOI/AsymmetricZOI.py
@@ -67,15 +67,18 @@ class AsymmetricZOI(ResourceModel):
         idx = np.where(bools)
         height = np.zeros_like(distance)
         #Here, the curved top of the plant is considered..
-        height[idx] = stem_height + (4 * crown_radius**2 -
-                                     distance[idx]**2)**0.5
+        if self.curved_crown:
+            height[idx] = stem_height + (4 * crown_radius ** 2 -
+                                         distance[idx] ** 2) ** 0.5
+        else:
+            height[idx] = stem_height + 2 * crown_radius
         return height, bools
 
     def getInputParameters(self, args):
         tags = {
             "prj_file": args,
             "required": ["type", "domain", "x_1", "x_2", "y_1", "y_2", "x_resolution", "y_resolution"],
-            "optional": ["allow_interpolation"]
+            "optional": ["allow_interpolation", "curved_crown"]
         }
         super().getInputParameters(**tags)
         self._x_1 = self.x_1
@@ -86,6 +89,12 @@ class AsymmetricZOI(ResourceModel):
         self.y_resolution = int(self.y_resolution)
 
         self.allow_interpolation = super().makeBoolFromArg("allow_interpolation")
+
+        if not hasattr(self, "curved_crown"):
+            self.curved_crown = True
+            print("INFO: set above-ground parameter curved_crown to default: ", self.curved_crown)
+        else:
+            self.curved_crown = super().makeBoolFromArg("curved_crown")
 
     def prepareNextTimeStep(self, t_ini, t_end):
         self.xe = []


### PR DESCRIPTION
This PR is in prepartation for unifying the plant geometries in pyMANGA.

So far, it is assumed that the crown of a plant has a curved shape in the AZOI module. This is now optional and can be switched off be setting the tag 'curved_crown' to False. However, this can lead to quite unstable results ('jumps' in the ag_factor estimation, see [here](https://github.com/pymanga/sensitivity/blob/main/ResourceLib/AboveGround/AsymmetricZOI/curved_crown/curved_crown.md))).